### PR TITLE
Feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,72 +1,37 @@
-name: build
-
+name: SonarCloud
 on:
   push:
     branches:
-      - main
       - master
-      - experimental-apex-parser
-    tags:
-      - '**'
   pull_request:
-  merge_group:
-  schedule:
-    # build it monthly: At 04:00 on day-of-month 1.
-    - cron:  '0 4 1 * *'
-  workflow_dispatch:
-
-permissions:
-  contents: read # to fetch code (actions/checkout)
-
+    types: [opened, synchronize, reopened]
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    permissions:
-      # read to fetch code (actions/checkout)
-      # write to push code to gh-pages, create releases
-      # note: forked repositories will have maximum read access
-      contents: write
-    continue-on-error: false
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    name: Build and analyze
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 2
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.m2/repository
-          ~/.gradle/caches
-          ~/.cache
-          ~/work/pmd/target/repositories
-          vendor/bundle
-        key: v3-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          v3-${{ runner.os }}-
-    - name: Set up Ruby 2.7
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.7
-    - name: Setup Environment
-      shell: bash
-      run: |
-        echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
-        echo "MAVEN_OPTS=-Dmaven.wagon.httpconnectionManager.ttlSeconds=180 -Dmaven.wagon.http.retryHandler.count=3 -DautoReleaseAfterClose=true -DstagingProgressTimeoutMinutes=30" >> $GITHUB_ENV
-        echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/21/scripts" >> $GITHUB_ENV
-    - name: Check Environment
-      shell: bash
-      run: |
-        f=check-environment.sh; \
-        mkdir -p .ci && \
-        ( [ -e .ci/$f ] || curl -sSL "${PMD_CI_SCRIPTS_URL}/$f" > ".ci/$f" ) && \
-        chmod 755 .ci/$f && \
-        .ci/$f
-    - name: Build
-      run: .ci/build.sh
-      shell: bash
-      env:
-        PMD_CI_SECRET_PASSPHRASE: ${{ secrets.PMD_CI_SECRET_PASSPHRASE }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'zulu' # Alternative distribution options are available.
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=Diya1201_pmd-Asn3b

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # PMD - source code analyzer
+[![SonarCloud](https://sonarcloud.io/images/project_badges/sonarcloud-black.svg)](https://sonarcloud.io/summary/new_code?id=Diya1201_pmd-Asn3b)
+
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=Diya1201_pmd-Asn3b&metric=bugs)](https://sonarcloud.io/summary/new_code?id=Diya1201_pmd-Asn3b)
 
 ![PMD Logo](https://raw.githubusercontent.com/pmd/pmd/pmd/7.0.x/docs/images/logo/pmd-logo-300px.png)
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,8 @@
 
         <antlr4.outputDirectory>${project.build.directory}/generated-sources/antlr4</antlr4.outputDirectory>
         <antlr4.ant.wrapper>${project.basedir}/../antlr4-wrapper.xml</antlr4.ant.wrapper>
+        <sonar.organization>diya1201</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 
     <build>


### PR DESCRIPTION
## Describe the PR

 Issue fixed:- Cognitive Complexity

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

 In this refactored version, I have extracted the logic for finding the next occurrence of a line terminator into a separate findNext method. I also created separate methods for handling each of the three possible cases for a line terminator: both CR and LF, no terminator, and a single terminator. Finally, I extracted the logic for resetting the lookahead variables into a separate resetLookahead method. By breaking the code down into these smaller methods, I can reduce the cognitive complexity and make the code easier to understand and maintain.
## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

